### PR TITLE
Add floats to react-box-size

### DIFF
--- a/demo/App.js
+++ b/demo/App.js
@@ -71,6 +71,17 @@ const App = () => {
           <code style={styles.code}>`pr={3}`</code>
         </Box>
       </Box>
+      <Box mv={6}>
+        <Box mb={1}>
+          <h2>Floats</h2>
+        </Box>
+        <Box style={styles.containerBox} float='left'>
+          <code style={styles.code}>`float="left"`</code>
+        </Box>
+        <Box style={styles.containerBox} float='right'>
+          <code style={styles.code}>`float="right"`</code>
+        </Box>
+      </Box>
     </Box>
   )
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack-dev-server",
+    "dev": "x0 dev demo/App.js",
     "test": "ava --verbose",
     "build": "NODE_ENV=production webpack -p",
     "prepublish": "babel src -d dist"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import scale from './scale'
 
-const Box = ({ mv, mh, mt, mb, ml, mr, pv, ph, pt, pb, pl, pr, ...props }) => {
+const Box = ({ mv, mh, mt, mb, ml, mr, pv, ph, pt, pb, pl, pr, float, ...props }) => {
   const styles = {
     // Margins
     marginTop: scale[mt || mv || 0],
@@ -15,6 +15,8 @@ const Box = ({ mv, mh, mt, mb, ml, mr, pv, ph, pt, pb, pl, pr, ...props }) => {
     paddingBottom: scale[pb || pv || 0],
     paddingLeft: scale[pl || ph || 0],
     paddingRight: scale[pr || ph || 0],
+    // Floats
+    float: float || 'none',
     // Add default styles
     ...props.style
   }
@@ -50,7 +52,10 @@ Box.propTypes = {
   // Left padding
   pl: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   // Right padding
-  pr: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  pr: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+
+  // Floats
+  float: PropTypes.oneOf(['left', 'right'])
 }
 
 export default Box


### PR DESCRIPTION
Adds floats to `react-box-size` and allows users to align items in various directions.

closes #1